### PR TITLE
fix: add the missing types

### DIFF
--- a/js/src/PDFDocument.d.ts
+++ b/js/src/PDFDocument.d.ts
@@ -21,6 +21,8 @@ export class PDFDocument {
   setPath: (path: string) => PDFDocument;
   modifyPage: ({ page }: PDFPage) => PDFDocument;
   modifyPages: (...pages: PDFPage[]) => PDFDocument;
+  loadPage: ({ page }: PDFPage) => PDFDocument;
+  loadPages: (...pages: PDFPage[]) => PDFDocument;
   addPage: ({ page }: PDFPage) => PDFDocument;
   addPages: (...pages: PDFPage[]) => PDFDocument;
   write: () => any;

--- a/js/src/PDFPage.d.ts
+++ b/js/src/PDFPage.d.ts
@@ -44,6 +44,7 @@ export class PDFPage {
   static create: () => PDFPage;
   static load: (pageIndex: any) => PDFPage;
   static modify: (pageIndex: any) => PDFPage;
+  static loadFromFile: (filePath: string, pageIndex?: number) => PDFPage;
   page: PageAction;
   setMediaBox: (width: number, height: number, options?: {
       x?: number;


### PR DESCRIPTION
Hi.
I have noticed that typing for typescript is missing:

For **PDFPage class** is missing type:
 `static loadFromFile: (filePath: string, pageIndex?: number) => PDFPage;`.
For **PDFDocument class** is missing types:
`loadPage: ({ page }: PDFPage) => PDFDocument;` and
`loadPages: (...pages: PDFPage[]) => PDFDocument;` 

Thanks